### PR TITLE
Implement get_canonical_quad.

### DIFF
--- a/src/nquads.rs
+++ b/src/nquads.rs
@@ -30,6 +30,13 @@ pub enum TermType {
   None,
 }
 
+pub enum Terms {
+  Subject,
+  Predicate,
+  Object,
+  Graph,
+}
+
 pub trait Term {
   fn new() -> Self;
   fn get_term_type(&self) -> &TermType;


### PR DESCRIPTION
Only copies/updates the quad as necessary.