### PR TITLE
Simplify loop

### DIFF
--- a/src/permuter.rs
+++ b/src/permuter.rs
@@ -59,9 +59,9 @@ impl Iterator for Permuter<'_> {
     let mut k_is_none = true;
     let mut pos = 0;
     let length = current.len();
-    for (i, permutator_elment) in current.iter().enumerate() {
-      let element = permutator_elment.value;
-      let left = permutator_elment.direction;
+    for (i, permutator_element) in current.iter().enumerate() {
+      let element = permutator_element.value;
+      let left = permutator_element.direction;
       k_is_none = k.is_none();
       if (k_is_none || element > k.unwrap().value)
         && ((left && i > 0 && element > current[i - 1].value)


### PR DESCRIPTION
TLDR; All this does is adjust some variable names and remove an intermediate variable.

### Research

So, in studying this.  I found that in the full rdf test suite, we do fall into this loop *sometimes*, but with the dataset there we *never* match the conditional on L87.

In particular, this loop is never activated at all in the hot path for a merge event operation, however, it *is* activated in the hot path for `test044_canonize`.

I performed micro and macro benchmarks after cutting out the loop entirely, which had no benefit, which may mean it is getting highly optimized already.

For future research... it would be nice to discover if we can eliminate this additional iteration over all the elements since as a practical matter, it is just waste.  I wonder if our dataset is such that it's not required.  

Also, this is a poster child for SIMD optimization which we may well be getting for free if rust vectorizes this code.